### PR TITLE
Skip alev

### DIFF
--- a/ece2cmor3/ece2cmor.py
+++ b/ece2cmor3/ece2cmor.py
@@ -123,12 +123,12 @@ def main(args=None):
         if attribute_value is not None:
             components.models[model][components.table_file] = attribute_value
 
-    filters = []
+    filters = None
     if args.skip_alevel_vars:
         def ifs_model_level_variable(target):
             zaxis, levs = cmor_target.get_z_axis(target)
             return zaxis not in ["alevel", "alevhalf"]
-        filters.append(ifs_model_level_variable)
+        filters = {"model level": ifs_model_level_variable}
 
     taskloader.load_targets(args.vars, model_active_flags, target_filters=filters)
 

--- a/ece2cmor3/ece2cmor.py
+++ b/ece2cmor3/ece2cmor.py
@@ -9,7 +9,7 @@ import logging
 import os
 import sys
 
-from ece2cmor3 import ece2cmorlib, taskloader, components, __version__
+from ece2cmor3 import ece2cmorlib, taskloader, components, __version__, cmor_target
 
 # Logger object
 log = logging.getLogger(__name__)
@@ -60,6 +60,8 @@ def main(args=None):
     parser.add_argument("--overwritemode", metavar="MODE", type=str, default="preserve",
                         help="MODE:preserve|replace|append, CMOR netcdf overwrite mode",
                         choices=["preserve", "replace", "append"])
+    parser.add_argument("--skip_alevel_vars", action="store_true", default=False, help="Prevent loading atmospheric "
+                                                                                       "model-level variables")
     parser.add_argument("-V", "--version", action="version",
                         version="%(prog)s {version}".format(version=__version__.version))
     # Deprecated arguments, only for backward compatibility
@@ -121,7 +123,14 @@ def main(args=None):
         if attribute_value is not None:
             components.models[model][components.table_file] = attribute_value
 
-    taskloader.load_targets(args.vars, model_active_flags)
+    filters = []
+    if args.skip_alevel_vars:
+        def ifs_model_level_variable(target):
+            zaxis, levs = cmor_target.get_z_axis(target)
+            return zaxis not in ["alevel", "alevhalf"]
+        filters.append(ifs_model_level_variable)
+
+    taskloader.load_targets(args.vars, model_active_flags, target_filters=filters)
 
     refdate = datetime.datetime.combine(dateutil.parser.parse(args.refd), datetime.datetime.min.time())
 

--- a/ece2cmor3/taskloader.py
+++ b/ece2cmor3/taskloader.py
@@ -43,7 +43,7 @@ with_pingfile = False
 
 
 # API function: loads the argument list of targets
-def load_targets(varlist, active_components=None, silent=False, target_filters=[]):
+def load_targets(varlist, active_components=None, silent=False, target_filters=None):
     global log
     targetlist = []
     if isinstance(varlist, basestring):
@@ -69,8 +69,13 @@ def load_targets(varlist, active_components=None, silent=False, target_filters=[
                 add_target(v, table, targetlist)
     else:
         log.error("Cannot create a list of cmor-targets for argument %s" % varlist)
-    for f in target_filters:
-        targetlist = filter(f, targetlist)
+    if target_filters is None:
+        target_filters = {}
+    for msg, func in target_filters.items():
+        filtered_list = filter(func, targetlist)
+        for tgt in list(set(targetlist) - set(filtered_list)):
+            log.info("Dismissing %s target variable %s in table %s..." % (msg, tgt.variable, tgt.table))
+        targetlist = filtered_list
     log.info("Found %d cmor target variables in input variable list." % len(targetlist))
     return create_tasks(targetlist, active_components, silent)
 

--- a/ece2cmor3/taskloader.py
+++ b/ece2cmor3/taskloader.py
@@ -43,7 +43,7 @@ with_pingfile = False
 
 
 # API function: loads the argument list of targets
-def load_targets(varlist, active_components=None, silent=False):
+def load_targets(varlist, active_components=None, silent=False, target_filters=[]):
     global log
     targetlist = []
     if isinstance(varlist, basestring):
@@ -69,6 +69,8 @@ def load_targets(varlist, active_components=None, silent=False):
                 add_target(v, table, targetlist)
     else:
         log.error("Cannot create a list of cmor-targets for argument %s" % varlist)
+    for f in target_filters:
+        targetlist = filter(f, targetlist)
     log.info("Found %d cmor target variables in input variable list." % len(targetlist))
     return create_tasks(targetlist, active_components, silent)
 


### PR DESCRIPTION
Added the --skip_alevel_vars option to ece2cmor script for dismissing IFS model level variables in an early stage