### PR TITLE
Remove duplicates

### DIFF
--- a/ece2cmor3/resources/prefs.py
+++ b/ece2cmor3/resources/prefs.py
@@ -1,6 +1,6 @@
 import logging
 
-from ece2cmor3 import components
+from ece2cmor3 import components, cmor_target
 
 
 def keep_variable(target, model_component, ecearth_config):
@@ -34,3 +34,24 @@ def keep_variable(target, model_component, ecearth_config):
         return model_component == "nemo" and ecearth_config == "EC-EARTH-CC"
 
     return True
+
+
+def choose_variable(target_list, model_component, ecearth_config):
+    # For IFS, skip variables that have been covered by others
+    if model_component == "ifs":
+        result = []
+        level_sets = map(cmor_target.get_z_axis, target_list)
+        for i in range(len(level_sets)):
+            level_type, levels = level_sets[i][0], set(level_sets[i][1])
+            add_to_list = True
+            for level_type_other, levels_other in level_sets:
+                if level_type == level_type_other and levels.issubset(set(levels_other)) \
+                        and not set(levels_other).issubset(levels):
+                    add_to_list = False
+                    break
+            if add_to_list:
+                result.append(target_list[i])
+        return result
+    return target_list
+
+

--- a/ece2cmor3/resources/prefs.py
+++ b/ece2cmor3/resources/prefs.py
@@ -37,7 +37,7 @@ def keep_variable(target, model_component, ecearth_config):
 
 
 def choose_variable(target_list, model_component, ecearth_config):
-    # For IFS, skip variables that have been covered by others
+    # For IFS, skip 3D variables on small level subsets in favor of extended level sets
     if model_component == "ifs":
         result = []
         level_sets = map(cmor_target.get_z_axis, target_list)
@@ -51,6 +51,10 @@ def choose_variable(target_list, model_component, ecearth_config):
                     break
             if add_to_list:
                 result.append(target_list[i])
+        # Incompatible variables fix: zg7h and zg27
+        vartabs = map(lambda t: (t.table, t.variable), result)
+        if ("6hrPlevPt", "zg7h") in vartabs and ("6hrPlevPt", "zg27") in vartabs:
+            result.remove([t for t in target_list if (t.table, t.variable) == ("6hrPlevPt", "zg27")][0])
         return result
     return target_list
 

--- a/test/taskloader_test.py
+++ b/test/taskloader_test.py
@@ -229,7 +229,6 @@ class taskloader_test(unittest.TestCase):
         finally:
             ece2cmorlib.finalize_without_cmor()
 
-
     @staticmethod
     def test_use_level_preferences():
         ece2cmorlib.initialize_without_cmor()
@@ -237,6 +236,17 @@ class taskloader_test(unittest.TestCase):
             matches, omitted = taskloader.load_drq({"6hrPlevPt": ["ua", "ua7h"]}, check_prefs=False)
             eq_(len(matches["ifs"]), 2)
             matches, omitted = taskloader.load_drq({"6hrPlevPt": ["ua", "ua7h"]}, check_prefs=True)
+            eq_(len(matches["ifs"]), 1)
+        finally:
+            ece2cmorlib.finalize_without_cmor()
+
+    @staticmethod
+    def test_use_zg_preferences():
+        ece2cmorlib.initialize_without_cmor()
+        try:
+            matches, omitted = taskloader.load_drq({"6hrPlevPt": ["zg7h", "zg27"]}, check_prefs=False)
+            eq_(len(matches["ifs"]), 2)
+            matches, omitted = taskloader.load_drq({"6hrPlevPt": ["zg7h", "zg27"]}, check_prefs=True)
             eq_(len(matches["ifs"]), 1)
         finally:
             ece2cmorlib.finalize_without_cmor()

--- a/test/taskloader_test.py
+++ b/test/taskloader_test.py
@@ -228,3 +228,15 @@ class taskloader_test(unittest.TestCase):
             eq_(len(matches["nemo"]), 1)
         finally:
             ece2cmorlib.finalize_without_cmor()
+
+
+    @staticmethod
+    def test_use_level_preferences():
+        ece2cmorlib.initialize_without_cmor()
+        try:
+            matches, omitted = taskloader.load_drq({"6hrPlevPt": ["ua", "ua7h"]}, check_prefs=False)
+            eq_(len(matches["ifs"]), 2)
+            matches, omitted = taskloader.load_drq({"6hrPlevPt": ["ua", "ua7h"]}, check_prefs=True)
+            eq_(len(matches["ifs"]), 1)
+        finally:
+            ece2cmorlib.finalize_without_cmor()


### PR DESCRIPTION
Made new preference function to filter out duplicate out_name variables on different pressure level sets (e.g. zg7h and zg27 in 6hrPlevPt which both cmorize to zg)