### PR TITLE
add support from compressed LPJG output files (.out.gz) - full optimized version TBD

### DIFF
--- a/ece2cmor3/lpjg2cmor.py
+++ b/ece2cmor3/lpjg2cmor.py
@@ -8,6 +8,10 @@ import numpy as np
 import pandas as pd
 from cdo import *
 
+# for compressed files
+import gzip
+import shutil
+
 from ece2cmor3 import cmor_utils, cmor_target, cmor_task
 
 # from cmor.Test.test_python_open_close_cmor_multiple import path
@@ -176,7 +180,16 @@ def execute(tasks):
                           (task.target.frequency, task.target.variable, task.target.table))
                 task.set_failed()
                 continue
-            lpjgfile = os.path.join(lpjg_path_, task.source.variable() + "_" + freqstr + ".out")
+
+            # if compressed file .out.gz file exists, uncompress it to temporary .out file
+            gzfile = os.path.join(lpjg_path_, task.source.variable() + "_" + freqstr + ".out.gz")
+            if os.path.exists(gzfile):
+                lpjgfile = os.path.join(ncpath_, task.source.variable() + "_" + freqstr + ".out")
+                log.info("Uncompressing file "+gzfile+" to temporary file "+lpjgfile)
+                with gzip.open(gzfile, 'rb') as f_in, open(lpjgfile, 'wb') as f_out:
+                    shutil.copyfileobj(f_in, f_out)
+            else:
+                lpjgfile = os.path.join(lpjg_path_, task.source.variable() + "_" + freqstr + ".out")
 
             if not os.path.exists(lpjgfile):
                 log.error("The file %s does not exist. Skipping CMORization of variable %s."
@@ -267,6 +280,12 @@ def execute(tasks):
                 # remove the regular (non-cmorized) netCDF file and the temporary .out file for current year
                 os.remove(ncfile)
                 os.remove(yearfile)
+
+            # end yearfile loop
+
+            # if compressed file .out.gz file exists, remove temporary .out file
+            if os.path.exists(gzfile):
+                os.remove(lpjgfile)
 
     return
 
@@ -405,12 +424,13 @@ def create_lpjg_netcdf(freq, inputfile, outname, outdims):
         df_list = [df]
 
     if freq.startswith("yr"):
-        log.info("Creating lpjg netcdf file for variable " + outname + " for year " + str(int(df_list[0].columns[0])))
+        str_year=str(int(df_list[0].columns[0]))
     else:
-        log.info(
-            "Creating lpjg netcdf file for variable " + outname + " for year " + str(int(df_list[0].columns[0][1])))
+        str_year=str(int(df_list[0].columns[0][1]))
 
-    ncfile = os.path.join(ncpath_, outname + "_" + freq + ".nc")
+    log.info( "Creating lpjg netcdf file for variable " + outname + " for year " + str_year )
+
+    ncfile = os.path.join(ncpath_, outname + "_" + freq + "_" + str_year + ".nc")
     # Note that ncfile could be named anything, it will be deleted later and the cmorization takes care of proper
     # naming conventions for the final file
 


### PR DESCRIPTION
This allows to read compressed LPJG output (saved as .out.gz).  To test this feature you can simply compress all .out.gz files using gzip. Output should be identical to that when cmorizing .out files.