### PR TITLE
Fix environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,33 +19,33 @@
 
 name: ece2cmor3
 channels:
-- conda-forge
-- defaults
+  - conda-forge
+  - defaults
 dependencies:
-- cmor=3.5.0                                      # Depends on libnetcdf >=4.6.1,<4.7, hdf5 >=1.10.3,<2, python >=2.7,<2.8
-- cdo=1.9.6
-- pyngl
-- python-cdo
-- conda-forge/label/cf202003::python-eccodes
-- netcdf4
-- nose=1.3.7
-- pip
-- requests
-- python=2.7.15
-- setuptools=39.2.0
-- numpy>=1.15.1
-- libiconv                                        # Unlisted dependency of cdo
-- pandas>=0.17.1
-- gitpython=2.1.11
-- nco                                             # Required by tem-diag
-- scipy                                           # Required by tem-diag
-- python-dateutil
-- pip:
-  - f90nml==0.20
-  - jsonschema==2.5.1
-  - testfixtures==5.3.1
-  - xlrd==1.1.0
-  - xlsxwriter==1.0.2
-  - dreqPy==01.00.33
-  - cython                                        # Unlisted dependency dreq 
-  - xarray                                        # Unlisted dependency dreq and/or drq
+  - cmor=3.5.0                                      # Depends on libnetcdf >=4.6.1,<4.7, hdf5 >=1.10.3,<2, python >=2.7,<2.8
+  - cdo=1.9.6
+  - pyngl
+  - python-cdo
+  - conda-forge/label/cf202003::python-eccodes
+  - netcdf4
+  - nose=1.3.7
+  - pip
+  - requests
+  - python=2.7.15
+  - setuptools=39.2.0
+  - numpy>=1.15.1
+  - libiconv                                        # Unlisted dependency of cdo
+  - pandas>=0.17.1
+  - gitpython=2.1.11
+  - nco                                             # Required by tem-diag
+  - scipy                                           # Required by tem-diag
+  - python-dateutil
+  - pip:
+    - f90nml==0.20
+    - jsonschema==2.5.1
+    - testfixtures==5.3.1
+    - xlrd==1.1.0
+    - xlsxwriter==1.0.2
+    - dreqPy==01.00.33
+    - cython                                        # Unlisted dependency dreq 
+    - xarray                                        # Unlisted dependency dreq and/or drq

--- a/environment.yml
+++ b/environment.yml
@@ -27,7 +27,7 @@ dependencies:
   - cmor=3.5.0
   # Unlisted dependency dreq
   - cython
-  - f90nml=0.20
+  - f90nml=0.21
   - gitpython=2.1.11
   - jsonschema=2.5.1
   # Unlisted dependency of cdo
@@ -48,7 +48,7 @@ dependencies:
   # Required by tem-diag
   - scipy
   - setuptools=39.2.0
-  - testfixtures=5.3.1
+  - testfixtures=5.4.0
   # Unlisted dependency dreq and/or drq
   - xarray
   - xlrd==1.1.0

--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,8 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - cmor=3.5.0                                      # Depends on libnetcdf >=4.6.1,<4.7, hdf5 >=1.10.3,<2, python >=2.7,<2.8
+  # Depends on libnetcdf >=4.6.1,<4.7, hdf5 >=1.10.3,<2, python >=2.7,<2.8
+  - cmor=3.5.0
   - cdo=1.9.6
   - pyngl
   - python-cdo
@@ -34,11 +35,14 @@ dependencies:
   - python=2.7.15
   - setuptools=39.2.0
   - numpy>=1.15.1
-  - libiconv                                        # Unlisted dependency of cdo
+  # Unlisted dependency of cdo
+  - libiconv
   - pandas>=0.17.1
   - gitpython=2.1.11
-  - nco                                             # Required by tem-diag
-  - scipy                                           # Required by tem-diag
+  # Required by tem-diag
+  - nco
+  # Required by tem-diag
+  - scipy
   - python-dateutil
   - pip:
     - f90nml==0.20
@@ -47,5 +51,7 @@ dependencies:
     - xlrd==1.1.0
     - xlsxwriter==1.0.2
     - dreqPy==01.00.33
-    - cython                                        # Unlisted dependency dreq 
-    - xarray                                        # Unlisted dependency dreq and/or drq
+    # Unlisted dependency dreq
+    - cython
+    # Unlisted dependency dreq and/or drq
+    - xarray

--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,11 @@ dependencies:
   - cdo=1.9.6
   # Depends on libnetcdf >=4.6.1,<4.7, hdf5 >=1.10.3,<2, python >=2.7,<2.8
   - cmor=3.5.0
+  # Unlisted dependency dreq
+  - cython
+  - f90nml=0.20
   - gitpython=2.1.11
+  - jsonschema=2.5.1
   # Unlisted dependency of cdo
   - libiconv
   # Required by tem-diag
@@ -44,14 +48,10 @@ dependencies:
   # Required by tem-diag
   - scipy
   - setuptools=39.2.0
+  - testfixtures=5.3.1
+  # Unlisted dependency dreq and/or drq
+  - xarray
+  - xlrd==1.1.0
+  - xlsxwriter==1.0.2
   - pip:
-    # Unlisted dependency dreq
-    - cython
     - dreqPy==01.00.33
-    - f90nml==0.20
-    - jsonschema==2.5.1
-    - testfixtures==5.3.1
-    # Unlisted dependency dreq and/or drq
-    - xarray
-    - xlrd==1.1.0
-    - xlsxwriter==1.0.2

--- a/environment.yml
+++ b/environment.yml
@@ -25,17 +25,12 @@ dependencies:
   - cdo
   # Depends on libnetcdf >=4.6.1,<4.7, hdf5 >=1.10.3,<2, python >=2.7,<2.8
   - cmor
-  # Unlisted dependency dreq
-  - cython
   - f90nml
   - gitpython
   - jsonschema
-  # Unlisted dependency of cdo
-  - libiconv
   # Required by tem-diag
   - nco
   - netcdf4
-  - nose
   - numpy
   - pandas
   - pip
@@ -47,8 +42,6 @@ dependencies:
   - requests
   # Required by tem-diag
   - scipy
-  - setuptools
-  - testfixtures
   # Unlisted dependency dreq and/or drq
   - xarray
   - xlrd

--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,7 @@
 name: ece2cmor3
 channels:
   - conda-forge
-  - defaults
+  - nodefaults
 dependencies:
   - cdo=1.9.6
   # Depends on libnetcdf >=4.6.1,<4.7, hdf5 >=1.10.3,<2, python >=2.7,<2.8

--- a/environment.yml
+++ b/environment.yml
@@ -22,36 +22,36 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - cdo=1.9.6
+  - cdo
   # Depends on libnetcdf >=4.6.1,<4.7, hdf5 >=1.10.3,<2, python >=2.7,<2.8
-  - cmor=3.5.0
+  - cmor
   # Unlisted dependency dreq
   - cython
-  - f90nml=0.21
-  - gitpython=2.1.11
-  - jsonschema=2.5.1
+  - f90nml
+  - gitpython
+  - jsonschema
   # Unlisted dependency of cdo
   - libiconv
   # Required by tem-diag
   - nco
   - netcdf4
-  - nose=1.3.7
-  - numpy>=1.15.1
-  - pandas>=0.17.1
+  - nose
+  - numpy
+  - pandas
   - pip
   - pyngl
-  - python=2.7.15
+  - python >=2.7,<3.0.a0
   - python-cdo
   - conda-forge/label/cf202003::python-eccodes
   - python-dateutil
   - requests
   # Required by tem-diag
   - scipy
-  - setuptools=39.2.0
-  - testfixtures=5.4.0
+  - setuptools
+  - testfixtures
   # Unlisted dependency dreq and/or drq
   - xarray
-  - xlrd==1.1.0
-  - xlsxwriter==1.0.2
+  - xlrd
+  - xlsxwriter
   - pip:
     - dreqPy==01.00.33

--- a/environment.yml
+++ b/environment.yml
@@ -26,7 +26,7 @@ dependencies:
 - cdo=1.9.6
 - pyngl
 - python-cdo
-- python-eccodes
+- conda-forge/label/cf202003::python-eccodes
 - netcdf4
 - nose=1.3.7
 - pip

--- a/environment.yml
+++ b/environment.yml
@@ -22,36 +22,36 @@ channels:
   - conda-forge
   - defaults
 dependencies:
+  - cdo=1.9.6
   # Depends on libnetcdf >=4.6.1,<4.7, hdf5 >=1.10.3,<2, python >=2.7,<2.8
   - cmor=3.5.0
-  - cdo=1.9.6
-  - pyngl
-  - python-cdo
-  - conda-forge/label/cf202003::python-eccodes
-  - netcdf4
-  - nose=1.3.7
-  - pip
-  - requests
-  - python=2.7.15
-  - setuptools=39.2.0
-  - numpy>=1.15.1
+  - gitpython=2.1.11
   # Unlisted dependency of cdo
   - libiconv
-  - pandas>=0.17.1
-  - gitpython=2.1.11
   # Required by tem-diag
   - nco
+  - netcdf4
+  - nose=1.3.7
+  - numpy>=1.15.1
+  - pandas>=0.17.1
+  - pip
+  - pyngl
+  - python=2.7.15
+  - python-cdo
+  - conda-forge/label/cf202003::python-eccodes
+  - python-dateutil
+  - requests
   # Required by tem-diag
   - scipy
-  - python-dateutil
+  - setuptools=39.2.0
   - pip:
+    # Unlisted dependency dreq
+    - cython
+    - dreqPy==01.00.33
     - f90nml==0.20
     - jsonschema==2.5.1
     - testfixtures==5.3.1
-    - xlrd==1.1.0
-    - xlsxwriter==1.0.2
-    - dreqPy==01.00.33
-    # Unlisted dependency dreq
-    - cython
     # Unlisted dependency dreq and/or drq
     - xarray
+    - xlrd==1.1.0
+    - xlsxwriter==1.0.2


### PR DESCRIPTION
This is an attempt to clean up the `environment.yml` file a little bit.

The most important change is the addition of the special `cf202003` label for the `python-eccodes` package, which permits the solution of the environment with Python 2.

The further commits are successively aggressive changes to simplify the file and hence the solving of the environment. Feel free to select only the first, some, or all of the commits for inclusion.

Fixes #729. 