### PR TITLE
Correct the tslsi mask and removing tr

### DIFF
--- a/ece2cmor3/resources/ifspar.json
+++ b/ece2cmor3/resources/ifspar.json
@@ -523,9 +523,7 @@
     {
         "source": "235.128",
         "target": [
-            "tslsi",
-            "tsland",
-            "tr"
+            "tsland"
         ],
         "masked": "land"
     },
@@ -930,6 +928,13 @@
         "source": "222.129",
         "target": "utendwtem",
         "post-proc": "make_dynvars"
+    },
+    {
+        "source": "235.129",
+        "target": [
+            "tslsi"
+        ],
+        "expr": "var235/(var31>0 || var172>0.5)"
     },
     {
         "mask": "land",


### PR DESCRIPTION
Correct the `tslsi` mask and removing `tr` because it was wrong and we cannot deliver it correctly #750.