### PR TITLE
Removed 'frac2percent' for all LPJG *Frac* variables

### DIFF
--- a/ece2cmor3/resources/lpjgpar.json
+++ b/ece2cmor3/resources/lpjgpar.json
@@ -1,7 +1,6 @@
 [
     {
         "source": "baresoilFrac",
-        "convert": "frac2percent",
         "target": "baresoilFrac"
     },
     {
@@ -78,17 +77,14 @@
     },
     {
         "source": "cropFrac",
-        "convert": "frac2percent",
         "target": "cropFrac"
     },
     {
         "source": "cropFracC3",
-        "convert": "frac2percent",
         "target": "cropFracC3"
     },
     {
         "source": "cropFracC4",
-        "convert": "frac2percent",
         "target": "cropFracC4"
     },
     {
@@ -337,17 +333,14 @@
     },
     {
         "source": "grassFrac",
-        "convert": "frac2percent",
         "target": "grassFrac"
     },
     {
         "source": "grassFracC3",
-        "convert": "frac2percent",
         "target": "grassFracC3"
     },
     {
         "source": "grassFracC4",
-        "convert": "frac2percent",
         "target": "grassFracC4"
     },
     {
@@ -364,7 +357,6 @@
     },
     {
         "source": "landCoverFrac",
-        "convert": "frac2percent",
         "target": "landCoverFrac"
     },
     {
@@ -501,22 +493,18 @@
     },
     {
         "source": "nwdFracLut",
-        "convert": "frac2percent",
         "target": "nwdFracLut"
     },
     {
         "source": "pastureFrac",
-        "convert": "frac2percent",
         "target": "pastureFrac"
     },
     {
         "source": "pastureFracC3",
-        "convert": "frac2percent",
         "target": "pastureFracC3"
     },
     {
         "source": "pastureFracC4",
-        "convert": "frac2percent",
         "target": "pastureFracC4"
     },
     {
@@ -561,7 +549,6 @@
     },
     {
         "source": "residualFrac",
-        "convert": "frac2percent",
         "target": "residualFrac"
     },
     {
@@ -590,7 +577,6 @@
     },
     {
         "source": "shrubFrac",
-        "convert": "frac2percent",
         "target": "shrubFrac"
     },
     {
@@ -611,27 +597,22 @@
     },
     {
         "source": "treeFrac",
-        "convert": "frac2percent",
         "target": "treeFrac"
     },
     {
         "source": "treeFracBdlDcd",
-        "convert": "frac2percent",
         "target": "treeFracBdlDcd"
     },
     {
         "source": "treeFracBdlEvg",
-        "convert": "frac2percent",
         "target": "treeFracBdlEvg"
     },
     {
         "source": "treeFracNdlDcd",
-        "convert": "frac2percent",
         "target": "treeFracNdlDcd"
     },
     {
         "source": "treeFracNdlEvg",
-        "convert": "frac2percent",
         "target": "treeFracNdlEvg"
     },
     {
@@ -640,7 +621,6 @@
     },
     {
         "source": "vegFrac",
-        "convert": "frac2percent",
         "target": "vegFrac"
     },
     {


### PR DESCRIPTION
In the original LPJG-code the units for \*Frac\* variables has been changed from [fraction] to [%] and, therefore, the auto-conversion has been removed in lpjgpar.json accordingly.
The issue is related to https://dev.ec-earth.org/issues/1312#note-221
Thanks @treerink !