### PR TITLE
Valid range for lpjg

### DIFF
--- a/ece2cmor3/lpjg2cmor.py
+++ b/ece2cmor3/lpjg2cmor.py
@@ -518,10 +518,10 @@ def create_lpjg_netcdf(freq, inputfile, outname, outdims):
     cdo = Cdo()
 
     if target_grid_ == "T159":
-        cdo.remapycon('n80', input="-setgrid," + gridfile_ + " " + temp_ncfile,
+        cdo.remapycon('n80', input="-setvrange,-1e16,1e16 -setgrid," + gridfile_ + " " + temp_ncfile,
                       output=ncfile)
     else:
-        cdo.remapycon('n128',input="-setgrid," + gridfile_ + " " + temp_ncfile,
+        cdo.remapycon('n128',input="-setvrange,-1e16,1e16 -setgrid," + gridfile_ + " " + temp_ncfile,
                       output=ncfile)  # TODO: add remapping for possible other grids
 
     os.remove(temp_ncfile)


### PR DESCRIPTION
Add valid range before remapping LPJG output on Gauss grid. This step is necessary to avoid problems if LPJG has saved NaNs, Infs or similar, e.g.
````
          Lon          Lat  Year  Day             Total
   138.000000    52.280560  1963    1 -670786273270042163794195022048781231865763317988975674731075817614860127027008331049106697530405240681585085977563046991280806607544018951619731042626422583012098048.000000000000
   138.000000    52.280560  1963    2 -670786273270042163794195022048781231865763317988975674731075817614860127027008331049106697530405240681585085977563046991280806607544018951619731042626422583012098048.000000000000
   138.000000    52.280560  1963    3 -670786273270042163794195022048781231865763317988975674731075817614860127027008331049106697530405240681585085977563046991280806607544018951619731042626422583012098048.000000000000
````