### PR TITLE
Fix #837: taking into account grids with names _grid_T_SFC

### DIFF
--- a/ece2cmor3/nemo2cmor.py
+++ b/ece2cmor3/nemo2cmor.py
@@ -634,7 +634,7 @@ def get_grid_type(grid_name):
     result = re.search(expr, grid_name)
     if result is not None:
         return 't'
-    expr = re.compile(r"(?i)grid_((T|U|V|W)_(2|3)D)|((T|U|V|W)$)")
+    expr = re.compile(r"(?i)grid_((T|U|V|W)_((2|3)D|SFC))|((T|U|V|W)$)")
     result = re.search(expr, grid_name)
     if not result:
         return None

--- a/test/nemo2cmor_test.py
+++ b/test/nemo2cmor_test.py
@@ -191,3 +191,4 @@ class nemo2cmor_tests(unittest.TestCase):
         assert nemo2cmor.get_grid_type("lim_grid_T_3D_ncatice") == 't'
         assert nemo2cmor.get_grid_type("opa_vert_sum") == 't'
         assert nemo2cmor.get_grid_type("opa_zoom_700_sum") == 't'
+        assert nemo2cmor.get_grid_type("pisces_grid_T_SFC") == 't'


### PR DESCRIPTION
Fix for issue #837, taking into account grids with names _grid_T_SFC (instead of _grid_T_2D).