### PR TITLE
added conversion factor for RESCUE tables

### DIFF
--- a/ece2cmor3/lpjg2cmor.py
+++ b/ece2cmor3/lpjg2cmor.py
@@ -808,6 +808,8 @@ def get_conversion_factor(conversion):
         return 100.0
     if conversion == "percent2frac":
         return 0.01
+    if conversion == "daily2persecond":
+        return 1./86400.
     log.error("Unknown explicit unit conversion %s will be ignored" % conversion)
     return 1.0
 


### PR DESCRIPTION
I have added the conversion factor "daily2persecond" for RESCUE (and the future) that reconverts daily data to secondly data. This saves a lot of storage in the LPJG ascii output. 