### PR TITLE
Fix GitHub workflow

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         submodules: true
     - name: Mamba install
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         activate-environment: ece2cmor3
         environment-file: environment.yml


### PR DESCRIPTION
Fix the immediate error for the Github tests for `ece2cmor3`.

The solution was found by reading this page: https://github.com/conda-incubator/setup-miniconda